### PR TITLE
feat: implement 2FA with Keycloak and DFSP user invitation emails

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -20,3 +20,6 @@ KEYCLOAK_ADMIN_CLIENT_ID=connection-manager-client
 KEYCLOAK_ADMIN_CLIENT_SECRET=client-secret
 KEYCLOAK_DFSPS_REALM=dfsps
 KEYCLOAK_AUTO_CREATE_ACCOUNTS=true
+
+# 2FA Authentication settings
+AUTH_2FA_ENABLED=false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - MYSQL_USER=mcm
       - MYSQL_PASSWORD=mcm
     healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      test: mysqladmin ping -h localhost
       timeout: 20s
       retries: 10
       start_period: 40s
@@ -33,22 +33,41 @@ services:
     cap_add:
       - IPC_LOCK
     healthcheck:
-      test: ["CMD-SHELL", "test -f /tmp/service_started"]
+      test: test -f /tmp/service_started
       timeout: 1s
       retries: 20
+
+  # MailHog for email testing
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"  # SMTP server
+      - "8025:8025"  # Web UI
+    healthcheck:
+      test: wget --spider --quiet http://localhost:8025
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
 
   keycloak:
     image: keycloak/keycloak:26.1
     entrypoint: /tmp/docker-entrypoint.sh
-    environment:
-      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
-      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
-      - DFSP_ADMIN_CLIENT_SECRET=${DFSP_ADMIN_CLIENT_SECRET}
+    env_file: "./keycloak/keycloak.env"
     volumes:
       - ./keycloak/dfsps-realm.json:/tmp/dfsps-realm-template.json
       - ./keycloak/docker-entrypoint.sh:/tmp/docker-entrypoint.sh
     ports:
       - "8080:8080"
+    depends_on:
+      mailhog:
+        condition: service_healthy
+    healthcheck:
+      test: curl --fail http://localhost:8080/health/ready
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
 #  connection-manager-api:
 #    build:
@@ -82,11 +101,11 @@ services:
 #    restart: always
 #    depends_on:
 #      connection-manager-db:
-#        condition: service_started
+#        condition: service_healthy
 #      vault-dev:
 #        condition: service_healthy
 #      keycloak:
-#        condition: service_started
+#        condition: service_healthy
 
 
   connection-manager-ui:
@@ -106,3 +125,7 @@ services:
     ports:
      - "8081:8080"
     restart: always
+    # Uncomment when the API service is active
+    #depends_on:
+    #  connection-manager-api:
+    #    condition: service_started

--- a/docker/keycloak/dfsps-realm.json
+++ b/docker/keycloak/dfsps-realm.json
@@ -82,5 +82,37 @@
         ]
       }
     ]
-  }
+  },
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {
+    "from": "noreply@mojaloop.io",
+    "fromDisplayName": "Mojaloop Hub",
+    "replyTo": "noreply@mojaloop.io",
+    "host": "mailhog",
+    "port": "1025",
+    "ssl": "false",
+    "starttls": "false",
+    "auth": "false"
+  },
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false
 } 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "connection-manager-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "connection-manager-api",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kubernetes/client-node": "^1.1.0",
+        "@kubernetes/client-node": "^1.1.2",
         "async-exit-hook": "^2.0.1",
         "async-retry": "^1.3.3",
         "body-parser": "^2.2.0",
         "connect": "^3.7.0",
         "cookies": "^0.9.1",
         "cors": "^2.8.5",
-        "dotenv": "^16.4.7",
+        "dotenv": "^16.5.0",
         "env-var": "^7.5.0",
         "express-winston": "^4.2.0",
         "form-data": "^4.0.2",
@@ -53,7 +53,7 @@
         "jshint": "^2.13.6",
         "mocha": "^11.1.0",
         "npm-audit-resolver": "3.0.0-RC.0",
-        "npm-check-updates": "^17.1.16",
+        "npm-check-updates": "^17.1.18",
         "nyc": "^17.1.0",
         "sinon": "^20.0.0",
         "snazzy": "^9.0.0",
@@ -1580,9 +1580,10 @@
       "optional": true
     },
     "node_modules/@kubernetes/client-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.1.0.tgz",
-      "integrity": "sha512-6Sp7ekNfMmDH2HvEQLb8vuPu+mX0xNkPElQLX5N/mjxeMimFWfecZeiFfIaG+Q9S1v+snZfTNJjvpOwNUVO7RA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.1.2.tgz",
+      "integrity": "sha512-kkE0D8zB5rIQoR6SUwlHUyQtpLvrW0gXOd2MabQsql7I2oPnMA8pb50A1MWB4yH0eX29t45gxs7lOVlS0UPsiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.1",
         "@types/node": "^22.0.0",
@@ -4205,9 +4206,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -9313,10 +9315,11 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.16",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.16.tgz",
-      "integrity": "sha512-9nohkfjLRzLfsLVGbO34eXBejvrOOTuw5tvNammH73KEFG5XlFoi3G2TgjTExHtnrKWCbZ+mTT+dbNeSjASIPw==",
+      "version": "17.1.18",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.18.tgz",
+      "integrity": "sha512-bkUy2g4v1i+3FeUf5fXMLbxmV95eG4/sS7lYE32GrUeVgQRfQEk39gpskksFunyaxQgTIdrvYbnuNbO/pSUSqw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "ncu": "build/cli.js",
         "npm-check-updates": "build/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connection-manager-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "ModusBox Connection Manager API",
   "license": "Apache-2.0",
   "author": "ModusBox",
@@ -57,14 +57,14 @@
     "swagger"
   ],
   "dependencies": {
-    "@kubernetes/client-node": "^1.1.0",
+    "@kubernetes/client-node": "^1.1.2",
     "async-exit-hook": "^2.0.1",
     "async-retry": "^1.3.3",
     "body-parser": "^2.2.0",
     "connect": "^3.7.0",
     "cookies": "^0.9.1",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
+    "dotenv": "^16.5.0",
     "env-var": "^7.5.0",
     "express-winston": "^4.2.0",
     "form-data": "^4.0.2",
@@ -101,7 +101,7 @@
     "jshint": "^2.13.6",
     "mocha": "^11.1.0",
     "npm-audit-resolver": "3.0.0-RC.0",
-    "npm-check-updates": "^17.1.16",
+    "npm-check-updates": "^17.1.18",
     "nyc": "^17.1.0",
     "sinon": "^20.0.0",
     "snazzy": "^9.0.0",

--- a/src/api/swagger.yaml
+++ b/src/api/swagger.yaml
@@ -2787,6 +2787,9 @@ components:
         securityGroup:
           type: string
           description: OAuth role/group owner
+        email:
+          type: string
+          description: DFSP operator email address for sending invitation
       example:
         dfspId: DFSP1
         name: DFSP 1


### PR DESCRIPTION
- Implement two-factor authentication (2FA) for DFSP operators using Keycloak TOTP
- Add functionality to send invitation emails upon DFSP user creation
- Enhance docker-compose and Keycloak realm configuration